### PR TITLE
Include a sample for parsing Rails logs

### DIFF
--- a/Configs/RailsLogs/rails_default_logger.conf
+++ b/Configs/RailsLogs/rails_default_logger.conf
@@ -1,0 +1,43 @@
+input {
+  # For GSwithELK we use generator to create some commonly seen Rails log formats
+  generator {
+    count => 3
+    lines => [
+      'I, [1970-01-01T00:00:00.109061 #12345]  INFO -- : Started GET "/users" for 127.0.0.1 at 1970-01-01 00:00:00 -0700',
+      'I, [1970-01-01T00:00:00.117117 #12345]  INFO -- : Processing by UsersController#index as HTML',
+      'I, [1970-01-01T00:00:00.131588 #12345]  INFO -- :   Rendered users/index.erb within layouts/application (0.6ms)',
+      'I, [1970-01-01T00:00:00.133606 #12345]  INFO -- : Completed 200 OK in 16ms (Views: 4.7ms | ActiveRecord: 0.0ms)'
+    ]
+  }
+}
+
+filter {
+  # Duplicate the original message into the "rails_message" field
+  mutate { add_field => ["rails_message", "%{message}"] }
+
+  # Match the common header from the production Rails log format
+  grok {
+    overwrite => ["message"]
+    match     => ["message", "^[A-Z], \[%{TIMESTAMP_ISO8601:timestamp} #%{POSINT:pid:int}\]%{SPACE}%{LOGLEVEL:level}%{SPACE}--%{SPACE}:%{SPACE}%{GREEDYDATA:message}"]
+  }
+
+  # Use the Rails timestamp as the event timestamp
+  date {
+    match        => ["timestamp", "ISO8601"]
+    remove_field => ["timestamp"]
+  }
+
+  # Match any of 4 known Rails log patterns
+  grok {
+    match => [
+      "message", '^Started %{WORD:verb} "%{NOTSPACE:uri}" for %{IPORHOST:client_ip} at %{TIMESTAMP_ISO8601}',
+      "message", "^Processing by %{WORD:controller}#%{WORD:method} as %{WORD:content_type}",
+      "message", "^Rendered %{NOTSPACE:partial} within %{NOTSPACE:layout} \(%{NUMBER:partial_render_time:float}m?s\)",
+      "message", "^Completed (?<status>%{POSINT} %{WORD}) in %{NUMBER:request_time:float}m?s \(Views: %{NUMBER:view_time:float}m?s \| ActiveRecord: %{NUMBER:db_query_time:float}m?s"
+    ]
+  }
+}
+
+output {
+  stdout { codec => rubydebug }
+}

--- a/Configs/RailsLogs/readme.txt
+++ b/Configs/RailsLogs/readme.txt
@@ -1,0 +1,8 @@
+This sample shows how to parse the common Rails request log format,
+however, it can easily be adapted for any log format that uses a common
+"header", followed by multiple arbitrary message formats.
+
+The most important part of this pattern, especially if you're looking to
+apply it to other log types, is the matching of the header information in
+a dedicated grok filter, and then using one or more separate filters to parse
+the various "sub-message" formats.


### PR DESCRIPTION
This includes a sample config for parsing Rails logs, that is also easy to adapt for any crappy log file, supporting multiple disparate message formats with a common header (/var/log/syslog and/or /var/log/messages comes to mind, among others).
