### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Structure
 
 - Configs -- These are example configs to work with a specific log type
 - Examples -- These are examples to use specific inputs/filters/codecs/outputs
-- Holding -- Items to be organized, or samples that need to be created and placed in other catagories
+- Holding -- Items to be organized, or samples that need to be created and placed in other categories
 - Logs -- Logs used in the examples
 - Snippets -- These are single bits that do cool things
 - Tuturials -- A set of configurations that are a step by step example of how to do something.


### PR DESCRIPTION
@coolacid, I've corrected a typographical error in the documentation of the [GettingStartedWithELK](https://github.com/coolacid/GettingStartedWithELK) project. Specifically, I've changed catagories to categories. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.